### PR TITLE
Users/charlowu/refactor precision recall

### DIFF
--- a/configs/dummy_pipelines/experimental_1.yaml
+++ b/configs/dummy_pipelines/experimental_1.yaml
@@ -63,5 +63,5 @@ analyses:
     - name: "precision_recall"
       model_names: [ "pwm", "vae" ]
       default_model_name: "humanTRB"
-      reference_data: "test"
+      reference_data: [ "train", "test" ]
       n_subsets: 10

--- a/configs/pipelines/experimental_1.yaml
+++ b/configs/pipelines/experimental_1.yaml
@@ -61,5 +61,5 @@ analyses:
     - name: "precision_recall"
       model_names: [ "pwm", "vae" ]
       default_model_name: "humanTRB"
-      reference_data: "test"
+      reference_data: [ "train", "test" ]
       n_subsets: 45

--- a/gen_airr_bm/analysis/analyse_precision_recall.py
+++ b/gen_airr_bm/analysis/analyse_precision_recall.py
@@ -12,6 +12,7 @@ from gen_airr_bm.utils.plotting_utils import plot_avg_scores, plot_grouped_bar_p
 
 @dataclass
 class ScoreStorage:
+    """ Class to store precision and recall scores for different models and datasets. """
     mean_precision: dict = field(default_factory=lambda: defaultdict(dict))
     std_precision: dict = field(default_factory=lambda: defaultdict(dict))
     mean_recall: dict = field(default_factory=lambda: defaultdict(dict))

--- a/gen_airr_bm/analysis/analyse_precision_recall.py
+++ b/gen_airr_bm/analysis/analyse_precision_recall.py
@@ -1,16 +1,32 @@
 import os
-from collections import defaultdict
-
 import numpy as np
 import pandas as pd
 
+from collections import defaultdict
+from dataclasses import dataclass, field
 from gen_airr_bm.core.analysis_config import AnalysisConfig
 from gen_airr_bm.utils.file_utils import get_sequence_files
 from gen_airr_bm.utils.compairr_utils import run_compairr_existence
 from gen_airr_bm.utils.plotting_utils import plot_avg_scores, plot_grouped_bar_precision_recall
 
 
+@dataclass
+class ScoreStorage:
+    mean_precision: dict = field(default_factory=lambda: defaultdict(dict))
+    std_precision: dict = field(default_factory=lambda: defaultdict(dict))
+    mean_recall: dict = field(default_factory=lambda: defaultdict(dict))
+    std_recall: dict = field(default_factory=lambda: defaultdict(dict))
+    precision_all: dict = field(default_factory=lambda: defaultdict(dict))
+    recall_all: dict = field(default_factory=lambda: defaultdict(dict))
+
+
 def run_precision_recall_analysis(analysis_config: AnalysisConfig):
+    """ Runs precision recall analysis on the generated and reference sequences.
+    Args:
+        analysis_config (AnalysisConfig): Configuration for the analysis, including paths and model names.
+    Returns:
+        None
+    """
     print("Running precision recall analysis")
 
     output_dir = analysis_config.analysis_output_dir
@@ -23,65 +39,118 @@ def run_precision_recall_analysis(analysis_config: AnalysisConfig):
 
 
 def compute_precision_recall_scores(analysis_config: AnalysisConfig, compairr_output_dir: str):
-    reference_data = analysis_config.reference_data
-    if not isinstance(reference_data, str):
-        raise ValueError("Reference data should be a single string for running precision recall analysis.")
+    """ Compute precision and recall scores and plot them.
+    Args:
+        analysis_config (AnalysisConfig): Configuration for the analysis, including paths and model names.
+        compairr_output_dir (str): Directory to store CompAIRR output files.
+    Returns:
+        None
+    """
+    train_reference = 'train' if 'train' in analysis_config.reference_data else None
+    test_reference = 'test' if 'test' in analysis_config.reference_data else None
+    if not test_reference:
+        raise ValueError("Could not run precision recall analysis without test data. 'test' required in reference_data "
+                         "list.")
+    else:
+        print(f"Continuing running precision recall analysis using {test_reference} as reference data...")
 
-    mean_precision_scores = defaultdict(lambda: defaultdict(list))
-    std_precision_scores = defaultdict(lambda: defaultdict(list))
-    mean_recall_scores = defaultdict(lambda: defaultdict(list))
-    std_recall_scores = defaultdict(lambda: defaultdict(list))
+    scores = ScoreStorage()
 
-    precision_scores_all = defaultdict(lambda: defaultdict(list))
-    recall_scores_all = defaultdict(lambda: defaultdict(list))
     for model in analysis_config.model_names:
-        comparison_files_dir = get_sequence_files(analysis_config, model, reference_data)
+        collect_model_scores(analysis_config, model, test_reference, compairr_output_dir, scores)
 
-        for ref_file, gen_files in comparison_files_dir.items():
-            dataset_name = os.path.splitext(os.path.basename(ref_file))[0]
+    if train_reference:
+        print(f"Adding upper reference scores using {train_reference} data.")
+        add_upper_reference(analysis_config, train_reference, test_reference, scores, compairr_output_dir)
 
-            precision_metrics, recall_metrics = get_precision_recall_metrics(ref_file, gen_files, compairr_output_dir, model)
-
-            mean_precision_scores[dataset_name][model] = np.mean(precision_metrics)
-            std_precision_scores[dataset_name][model] = np.std(precision_metrics)
-            mean_recall_scores[dataset_name][model] = np.mean(recall_metrics)
-            std_recall_scores[dataset_name][model] = np.std(recall_metrics)
-
-            precision_scores_all[dataset_name][model] = precision_metrics
-            recall_scores_all[dataset_name][model] = recall_metrics
-
-    # Add upper reference of precision recall between train and test
-    test_dir = f"{analysis_config.root_output_dir}/{reference_data}_compairr_sequences"
-    train_dir = f"{analysis_config.root_output_dir}/train_compairr_sequences"
-    for dataset in mean_precision_scores.keys():
-        train_file = f"{train_dir}/{dataset}.tsv"
-        test_file = f"{test_dir}/{dataset}.tsv"
-        ref_precision, ref_recall = get_precision_recall_reference(train_file, test_file, compairr_output_dir,
-                                                                   "upper_reference")
-        precision_scores_all[dataset]["upper_reference"] = [ref_precision]
-        recall_scores_all[dataset]["upper_reference"] = [ref_recall]
-
-    for dataset in mean_precision_scores:
-        plot_avg_scores(mean_precision_scores[dataset], std_precision_scores[dataset], analysis_config.analysis_output_dir,
-                        "precision", f"{dataset}_precision.png", "precision",
+    for dataset in scores.mean_precision:
+        plot_avg_scores(scores.mean_precision[dataset], scores.std_precision[dataset],
+                        analysis_config.analysis_output_dir, "precision",
+                        f"{dataset}_precision.png", "precision",
                         scoring_method="precision")
 
-        plot_avg_scores(mean_recall_scores[dataset], std_recall_scores[dataset], analysis_config.analysis_output_dir,
-                        "recall", f"{dataset}_recall.png", "recall",
+        plot_avg_scores(scores.mean_recall[dataset], scores.std_recall[dataset],
+                        analysis_config.analysis_output_dir, "recall",
+                        f"{dataset}_recall.png", "recall",
                         scoring_method="recall")
 
-    # barchart of precision and recall scores
-    plot_grouped_bar_precision_recall(precision_scores_all, recall_scores_all,
-                                      analysis_config.analysis_output_dir, analysis_config.reference_data)
+    plot_grouped_bar_precision_recall(scores.precision_all, scores.recall_all,
+                                      analysis_config.analysis_output_dir, test_reference)
 
 
-def get_precision_recall_metrics(ref_file, gen_files, compairr_output_dir, model):
+def collect_model_scores(analysis_config: AnalysisConfig, model: str, test_reference: str, compairr_output_dir: str,
+                         scores: ScoreStorage):
+    """ Collect precision and recall scores for a given model.
+    Args:
+        analysis_config (AnalysisConfig): Configuration for the analysis, including paths and model names.
+        model (str): Name of the model to analyze.
+        test_reference (str): Reference dataset for testing.
+        compairr_output_dir (str): Directory to store CompAIRR output files.
+        scores (ScoreStorage): Storage for precision and recall scores.
+    Returns:
+        None
+    """
+    comparison_files_dir = get_sequence_files(analysis_config, model, test_reference)
+
+    for ref_file, gen_files in comparison_files_dir.items():
+        dataset_name = os.path.splitext(os.path.basename(ref_file))[0]
+
+        precision_metrics, recall_metrics = get_precision_recall_metrics(ref_file, gen_files, compairr_output_dir,
+                                                                         model)
+
+        mean_p, std_p = np.mean(precision_metrics), np.std(precision_metrics)
+        mean_r, std_r = np.mean(recall_metrics), np.std(recall_metrics)
+
+        scores.mean_precision[dataset_name][model] = mean_p
+        scores.std_precision[dataset_name][model] = std_p
+        scores.mean_recall[dataset_name][model] = mean_r
+        scores.std_recall[dataset_name][model] = std_r
+
+        scores.precision_all[dataset_name][model] = precision_metrics
+        scores.recall_all[dataset_name][model] = recall_metrics
+
+
+def add_upper_reference(analysis_config: AnalysisConfig, train_reference: str, test_reference: str,
+                        scores: ScoreStorage, compairr_output_dir: str):
+    """ Add upper reference precision/recall scores between train and test data.
+    Args:
+        analysis_config (AnalysisConfig): Configuration for the analysis, including paths and model names.
+        train_reference (str): Reference dataset train to compare with test data.
+        test_reference (str): Reference dataset test to compare with train data.
+        scores (ScoreStorage): Storage for precision and recall scores.
+        compairr_output_dir (str): Directory to store CompAIRR output files.
+    Returns:
+        None
+    """
+    test_dir = f"{analysis_config.root_output_dir}/{test_reference}_compairr_sequences"
+    train_dir = f"{analysis_config.root_output_dir}/{train_reference}_compairr_sequences"
+
+    for dataset in scores.mean_precision.keys():
+        train_file = f"{train_dir}/{dataset}.tsv"
+        test_file = f"{test_dir}/{dataset}.tsv"
+
+        ref_precision, ref_recall = get_precision_recall_reference(train_file, test_file, compairr_output_dir)
+
+        scores.precision_all[dataset]["upper_reference"] = [ref_precision]
+        scores.recall_all[dataset]["upper_reference"] = [ref_recall]
+
+
+def get_precision_recall_metrics(ref_file: str, gen_files: list, compairr_output_dir: str, model: str):
+    """ Get precision and recall metrics for the generated files compared to the reference file.
+    Args:
+        ref_file (str): Path to the reference file.
+        gen_files (list): List of paths to generated files.
+        compairr_output_dir (str): Directory to store CompAIRR output files.
+        model (str): Name of the model used for generation.
+    Returns:
+        tuple: Lists of precision and recall metrics for the generated files.
+    """
     precision_metrics, recall_metrics = [], []
     for gen_file in gen_files:
         precision = compute_compairr_overlap_ratio(gen_file, ref_file, compairr_output_dir,
-                                                         model, "precision")
+                                                   model, "precision")
         recall = compute_compairr_overlap_ratio(ref_file, gen_file, compairr_output_dir,
-                                                  model, "recall")
+                                                model, "recall")
 
         precision_metrics.append(precision)
         recall_metrics.append(recall)
@@ -89,15 +158,35 @@ def get_precision_recall_metrics(ref_file, gen_files, compairr_output_dir, model
     return precision_metrics, recall_metrics
 
 
-def get_precision_recall_reference(train_file, test_file, compairr_output_dir, model):
+def get_precision_recall_reference(train_file, test_file, compairr_output_dir):
+    """ Get precision and recall metrics for the upper reference between train and test files.
+    Args:
+        train_file (str): Path to the train file (train used as replacement of generated (model) file for upper
+        reference.
+        test_file (str): Path to the test file.
+        compairr_output_dir (str): Directory to store CompAIRR output files.
+    Returns:
+        tuple: Precision and recall metrics for the upper reference.
+    """
     precision = compute_compairr_overlap_ratio(train_file, test_file, compairr_output_dir,
-                                               model, "precision")
+                                               'upper_reference', "precision")
     recall = compute_compairr_overlap_ratio(test_file, train_file, compairr_output_dir,
-                                            model, "recall")
+                                            'upper_reference', "recall")
     return precision, recall
 
 
-def compute_compairr_overlap_ratio(search_for_file, search_in_file, compairr_output_dir, model_name, metric):
+def compute_compairr_overlap_ratio(search_for_file: str, search_in_file: str, compairr_output_dir: str, model_name: str,
+                                   metric: str) -> float:
+    """ Compute the overlap ratio between two sequence sets using CompAIRR for precision or recall.
+    Args:
+        search_for_file (str): Path to the file of sequences for which to search for existence in another sequence set.
+        search_in_file (str): Path to the file to search for existence in.
+        compairr_output_dir (str): Directory to store CompAIRR output files.
+        model_name (str): Name of the model used for generation, or "upper_reference" for the upper reference.
+        metric (str): Metric type, either "precision" or "recall".
+    Returns:
+        float: Ratio of non-zero overlap counts to total counts.
+    """
     if metric == "precision":
         file_name = f"{os.path.splitext(os.path.basename(search_for_file))[0]}_{model_name}_{metric}"
     else:

--- a/tests/analysis/test_analyse_precision_recall.py
+++ b/tests/analysis/test_analyse_precision_recall.py
@@ -1,0 +1,145 @@
+import pytest
+import pandas as pd
+
+from gen_airr_bm.analysis.analyse_precision_recall import (
+    run_precision_recall_analysis,
+    compute_precision_recall_scores,
+    collect_model_scores,
+    add_upper_reference,
+    get_precision_recall_metrics,
+    get_precision_recall_reference,
+    compute_compairr_overlap_ratio,
+    ScoreStorage,
+)
+from gen_airr_bm.core.analysis_config import AnalysisConfig
+
+
+@pytest.fixture
+def sample_analysis_config():
+    return AnalysisConfig(
+        analysis="precision_recall",
+        model_names=["modelA", "modelB"],
+        analysis_output_dir="/tmp/test_output/analysis",
+        root_output_dir="/tmp/test_output",
+        default_model_name="humanTRB",
+        reference_data=["train", "test"],  # include both for upper reference
+        n_subsets=3,
+        n_unique_samples=10,
+    )
+
+
+def test_run_precision_recall_analysis_full_pipeline(mocker, sample_analysis_config):
+    os_makedirs = mocker.patch("os.makedirs")
+    mock_compute = mocker.patch("gen_airr_bm.analysis.analyse_precision_recall.compute_precision_recall_scores")
+
+    run_precision_recall_analysis(sample_analysis_config)
+
+    os_makedirs.assert_any_call("/tmp/test_output/analysis", exist_ok=True)
+    os_makedirs.assert_any_call("/tmp/test_output/analysis/compairr_output", exist_ok=True)
+    mock_compute.assert_called_once()
+
+
+def test_compute_precision_recall_scores_happy_path(mocker, sample_analysis_config):
+    # Mocks for low-level helpers and plotting
+    mock_collect = mocker.patch(
+        "gen_airr_bm.analysis.analyse_precision_recall.collect_model_scores", autospec=True
+    )
+    mock_add_ref = mocker.patch(
+        "gen_airr_bm.analysis.analyse_precision_recall.add_upper_reference", autospec=True
+    )
+    mock_plot_avg = mocker.patch("gen_airr_bm.analysis.analyse_precision_recall.plot_avg_scores")
+    mock_plot_grouped = mocker.patch("gen_airr_bm.analysis.analyse_precision_recall.plot_grouped_bar_precision_recall")
+
+    # Patch ScoreStorage so mean_precision dict isn't just empty
+    fake_scores = ScoreStorage()
+    datasets = ["ds1", "ds2"]
+    for ds in datasets:
+        fake_scores.mean_precision[ds] = {"modelA": 0.8, "modelB": 0.5}
+        fake_scores.std_precision[ds] = {"modelA": 0.05, "modelB": 0.10}
+        fake_scores.mean_recall[ds] = {"modelA": 0.7, "modelB": 0.6}
+        fake_scores.std_recall[ds] = {"modelA": 0.03, "modelB": 0.09}
+        fake_scores.precision_all[ds] = {"modelA": [0.8], "modelB": [0.5]}
+        fake_scores.recall_all[ds] = {"modelA": [0.7], "modelB": [0.6]}
+    mock_collect.side_effect = lambda ac, m, t, c, s: fake_scores
+
+    # Patch ScoreStorage instantiation
+    mocker.patch("gen_airr_bm.analysis.analyse_precision_recall.ScoreStorage", return_value=fake_scores)
+
+    compute_precision_recall_scores(sample_analysis_config, "/tmp/test_output/analysis/compairr_output")
+    assert mock_collect.call_count == len(sample_analysis_config.model_names)
+    mock_add_ref.assert_called_once()
+    # Should plot for each dataset
+    assert mock_plot_avg.call_count == 2 * len(datasets)
+    mock_plot_grouped.assert_called_once()
+
+
+def test_collect_model_scores_invokes_deps_and_updates_scores(mocker, sample_analysis_config):
+    # Setup fixture and mocks
+    mock_get_seq_files = mocker.patch(
+        "gen_airr_bm.analysis.analyse_precision_recall.get_sequence_files",
+        return_value={
+            "/tmp/test_output/test_compairr_sequences/ds1.tsv": {
+                "/tmp/test_output/generated_compairr_sequences_split/modelA/ds1_0.tsv"},
+            "/tmp/test_output/test_compairr_sequences/ds2.tsv": {
+                "/tmp/test_output/generated_compairr_sequences_split/modelA/ds2_0.tsv"}
+        }
+    )
+    mock_get_metrics = mocker.patch(
+        "gen_airr_bm.analysis.analyse_precision_recall.get_precision_recall_metrics",
+        side_effect=lambda ref, gen, out, model: ([0.9], [0.8])
+    )
+    storage = ScoreStorage()
+    collect_model_scores(sample_analysis_config, "modelA", "test", "/tmp/compairr_out", storage)
+    assert storage.mean_precision["ds1"]["modelA"] == 0.9
+    assert storage.std_recall["ds2"]["modelA"] == 0.0  # Only one value, std=0
+
+
+def test_add_upper_reference_flows_and_updates_scores(mocker, sample_analysis_config):
+    mock_get_ref = mocker.patch(
+        "gen_airr_bm.analysis.analyse_precision_recall.get_precision_recall_reference",
+        return_value=(0.99, 0.88)
+    )
+    ss = ScoreStorage()
+    # Must pre-populate mean_precision keys for loop
+    ss.mean_precision["ds3"] = {}
+    add_upper_reference(sample_analysis_config, "train", "test", ss, "/tmp/compairr_out")
+    assert ss.precision_all["ds3"]["upper_reference"] == [0.99]
+    assert ss.recall_all["ds3"]["upper_reference"] == [0.88]
+
+
+def test_get_precision_recall_metrics(mocker):
+    mock_overlap = mocker.patch(
+        "gen_airr_bm.analysis.analyse_precision_recall.compute_compairr_overlap_ratio",
+        side_effect=[0.81, 0.61]
+    )
+    precision, recall = get_precision_recall_metrics("ref.tsv", ["gen1.tsv"], "/tmp/out", "myModel")
+    mock_overlap.assert_any_call("gen1.tsv", "ref.tsv", "/tmp/out", "myModel", "precision")
+    mock_overlap.assert_any_call("ref.tsv", "gen1.tsv", "/tmp/out", "myModel", "recall")
+    assert precision == [0.81]
+    assert recall == [0.61]
+
+
+def test_get_precision_recall_reference(mocker):
+    mock_overlap = mocker.patch("gen_airr_bm.analysis.analyse_precision_recall.compute_compairr_overlap_ratio",
+                                side_effect=[0.76, 0.55])
+    p, r = get_precision_recall_reference("train.tsv", "test.tsv", "/tmp/out")
+    mock_overlap.assert_any_call("train.tsv", "test.tsv", "/tmp/out", "upper_reference", "precision")
+    mock_overlap.assert_any_call("test.tsv", "train.tsv", "/tmp/out", "upper_reference", "recall")
+    assert p == 0.76
+    assert r == 0.55
+
+
+def test_compute_compairr_overlap_ratio_reads_result(mocker, tmp_path):
+    out_dir = tmp_path
+    simple_path = out_dir / "somefile.tsv"
+    # The path that will be READ is (according to function logic):
+    overlap_fname = f"{simple_path.stem}_modelA_precision_overlap.tsv"
+    overlap_path = out_dir / overlap_fname
+    df = pd.DataFrame({"sequence_id": ["id1", "id2", "id3"], "overlap_count": [1, 0, 2]})
+    df.to_csv(overlap_path, sep="\t", index=False)
+    mocker.patch("gen_airr_bm.analysis.analyse_precision_recall.run_compairr_existence", return_value=None)
+    ratio = compute_compairr_overlap_ratio(
+        str(simple_path), "other.tsv", str(out_dir), "modelA", "precision"
+    )
+    assert ratio == pytest.approx(2 / 3, 0.01)
+


### PR DESCRIPTION
In this PR:
- I adapted precision recall analysis to take in reference_data as list from the config. The analysis returns an error if 'test' is not in the list. If 'train' is in the list, upper_reference is included in the analysis. In this way, it is still hardcoded to always use test as the reference set when looking for overlap with generated sequence sets, and upper reference is still always computed between train and test (with train just replacing model)
- I refactored and cleaned functions for better readability
- added doc strings in precision recall analysis
- added a test for precision recall analysis